### PR TITLE
fix: Added region and signature for S3 bucket

### DIFF
--- a/openassessment/fileupload/backends/s3.py
+++ b/openassessment/fileupload/backends/s3.py
@@ -8,6 +8,8 @@ from django.conf import settings
 import botocore
 import boto3
 
+from botocore.client import Config
+
 from ..exceptions import FileUploadInternalError
 from .base import BaseBackend
 
@@ -75,12 +77,18 @@ def _connect_to_s3():
     aws_access_key_id = getattr(settings, "AWS_ACCESS_KEY_ID", None)
     aws_secret_access_key = getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
     endpoint_url = getattr(settings, "AWS_S3_ENDPOINT_URL", None)
+    signature_version = getattr(settings, "AWS_S3_SIGNATURE_VERSION ", None)
+    region_name = getattr(settings, "AWS_S3_REGION_NAME", None)
 
     return boto3.client(
         "s3",
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         endpoint_url=endpoint_url,
+        config=Config(
+            signature_version=signature_version,
+            region_name=region_name
+        )
     )
 
 


### PR DESCRIPTION
For a region based bucket boto3 needs to know about region and signature which edx-ora2 doesn't know about.

**JIRA tickets**:  TBD

**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.

**Dependencies**: None

**Screenshots**: Always include screenshots if there is any change to the UI.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

TBD